### PR TITLE
Add console test runner

### DIFF
--- a/ConsoleTest/ConsoleTest.fsproj
+++ b/ConsoleTest/ConsoleTest.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReasoningEngine\ReasoningEngine.fsproj" />
+    <ProjectReference Include="..\RENotebookApi\RENotebookApi.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+  </ItemGroup>
+
+</Project>

--- a/ConsoleTest/Program.fs
+++ b/ConsoleTest/Program.fs
@@ -1,0 +1,51 @@
+﻿open System
+
+open Microsoft.Research.ReasoningEngine
+open Microsoft.Research.RENotebook
+
+type ReilAPI = Microsoft.Research.RENotebook.REIL
+
+let test_inputs = [
+    "state int x;";
+
+    """
+    state int x;
+    update p[k].x := p[k-1].x + 1;
+    #test[0].x = 0;
+    #test[10].x > 0;
+    """;
+
+    """
+    state int x;
+    update p[k].x := p[k-1].x + 1;
+    #test[10].x > 20;
+    """;
+
+    """
+    state int x;
+    update p[k].x := p[k-1].x + 1;
+    #test1[10].x > 20;
+    #test2[10].x < 5;
+    """;
+
+    """
+    unique state int temperature;
+    unique state bool heatIsOn;
+    update
+        p[k].temperature := if (p[k-1].heatIsOn) then (p[k-1].temperature + 1) else (p[k-1].temperature - 1),
+        p[k].heatIsOn := p[k-1].temperature < 18;
+
+    #test[0].temperature = 20;
+    #test[10].temperature < 18;
+    """
+]
+
+[<EntryPoint>]
+let main argv =
+    for test_input in test_inputs do
+        let model = ReilAPI.Load test_input in
+        let solution = ReilAPI.Check model in
+        match (solution) with
+        | Some(x) -> printfn "Solution (%d paths): %s" x.paths.Count (x.ToString())
+        | None -> printfn "No solution."
+    0

--- a/RENotebookApi/RENotebookApi.fsproj
+++ b/RENotebookApi/RENotebookApi.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -19,6 +19,12 @@
     <None Include="app.config" />
     <None Include="paket.references" />
     <None Include="ReLoad.fsx" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutomaticGraphLayout" Version="1.1.9" />
+    <PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.9" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
+    <PackageReference Include="XPlot.Plotly" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReasoningEngine\ReasoningEngine.fsproj" />


### PR DESCRIPTION
Adds a simple command-line test runner that can be used to run and debug locally, without the need for Jupyter notebooks.

Note the changes to `RENotebookApi\RENotebookApi.fsproj`; I'm not sure which .NET framework we want to use, but in my opinion, this should all be `netstandard2.0` and not `net472`.