### PR TITLE
Fix the parsers for current F# rules and update for dotnet interactive changes

### DIFF
--- a/REIN/Parser.fs
+++ b/REIN/Parser.fs
@@ -5,27 +5,27 @@ open FSharp.Text.Lexing
 open FSharp.Text.Parsing.ParseHelpers
 # 1 "Parser.fsy"
 
+
+
 open System
 open Microsoft.Research.ReasoningEngine.Constraint
 open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
-#indent "off"
-
 type Line = 
-	|Assign of string * BExpr
-	|Assert of BExpr  * string option	 //boolean expression * description	option
-	|Interaction of string * string * bool * bool //source * target * positive? * definite?
-	|Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
-	|Directive of Directive //possibly, create more structured directives
-	
+    |Assign of string * BExpr
+    |Assert of BExpr  * string option //boolean expression * description    option
+    |Interaction of string * string * bool * bool //source * target * positive? * definite?
+    |Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
+    |Directive of Directive //possibly, create more structured directives
+    
 and Directive = 
-	|Uniqueness of Settings.Uniqueness
+    |Uniqueness of Settings.Uniqueness
     |Interaction_limit of int option
     |Regulation of Settings.RegulationConditions
     |Traj_length of int
-    |Updates of Settings.Updates		
-	|PreventRepeats
+    |Updates of Settings.Updates        
+    |PreventRepeats
 
 # 30 "Parser.fs"
 // This type is the type of tokens accepted by the parser
@@ -590,7 +590,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 70 "Parser.fsy"
-                                                         Assign(_1,_4)		  
+                                                         Assign(_1,_4)          
                    )
 # 70 "Parser.fsy"
                  : 'Line));
@@ -644,7 +644,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 77 "Parser.fsy"
-                                           Uniqueness(Settings.Model)		
+                                           Uniqueness(Settings.Model)        
                    )
 # 77 "Parser.fsy"
                  : 'Directive));
@@ -654,7 +654,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 78 "Parser.fsy"
-                                            Uniqueness(Settings.All)			
+                                            Uniqueness(Settings.All)            
                    )
 # 78 "Parser.fsy"
                  : 'Directive));
@@ -666,7 +666,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 79 "Parser.fsy"
-                                                    Uniqueness(Settings.Path(_3,_4))	
+                                                    Uniqueness(Settings.Path(_3,_4))    
                    )
 # 79 "Parser.fsy"
                  : 'Directive));
@@ -676,7 +676,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 80 "Parser.fsy"
-                                              Regulation(Settings.Default)		
+                                              Regulation(Settings.Default)        
                    )
 # 80 "Parser.fsy"
                  : 'Directive));
@@ -686,7 +686,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 81 "Parser.fsy"
-                                                 Regulation(Settings.Cardinality)	
+                                                 Regulation(Settings.Cardinality)    
                    )
 # 81 "Parser.fsy"
                  : 'Directive));
@@ -696,7 +696,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 82 "Parser.fsy"
-                                             Regulation(Settings.Legacy)		
+                                             Regulation(Settings.Legacy)        
                    )
 # 82 "Parser.fsy"
                  : 'Directive));
@@ -706,7 +706,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 83 "Parser.fsy"
-                                                 Regulation(Settings.NoThresholds)	
+                                                 Regulation(Settings.NoThresholds)    
                    )
 # 83 "Parser.fsy"
                  : 'Directive));
@@ -716,7 +716,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 84 "Parser.fsy"
-                                         Updates(Settings.Synchronous)		
+                                         Updates(Settings.Synchronous)        
                    )
 # 84 "Parser.fsy"
                  : 'Directive));
@@ -726,7 +726,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 85 "Parser.fsy"
-                                          Updates(Settings.Asynchronous)	
+                                          Updates(Settings.Asynchronous)    
                    )
 # 85 "Parser.fsy"
                  : 'Directive));
@@ -737,7 +737,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 86 "Parser.fsy"
-                                        Interaction_limit(Some(_2))		
+                                        Interaction_limit(Some(_2))        
                    )
 # 86 "Parser.fsy"
                  : 'Directive));
@@ -748,7 +748,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 87 "Parser.fsy"
-                                         Traj_length(_2)					
+                                         Traj_length(_2)                    
                    )
 # 87 "Parser.fsy"
                  : 'Directive));

--- a/REIN/Parser.fsy
+++ b/REIN/Parser.fsy
@@ -4,22 +4,22 @@ open Microsoft.Research.ReasoningEngine.Constraint
 open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
-#indent "off"
+
 
 type Line = 
-	|Assign of string * BExpr
-	|Assert of BExpr  * string option	 //boolean expression * description	option
-	|Interaction of string * string * bool * bool //source * target * positive? * definite?
-	|Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
-	|Directive of Directive //possibly, create more structured directives
-	
+    |Assign of string * BExpr
+    |Assert of BExpr  * string option     //boolean expression * description    option
+    |Interaction of string * string * bool * bool //source * target * positive? * definite?
+    |Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
+    |Directive of Directive //possibly, create more structured directives
+    
 and Directive = 
-	|Uniqueness of Settings.Uniqueness
+    |Uniqueness of Settings.Uniqueness
     |Interaction_limit of int option
     |Regulation of Settings.RegulationConditions
     |Traj_length of int
-    |Updates of Settings.Updates		
-	|PreventRepeats
+    |Updates of Settings.Updates        
+    |PreventRepeats
 %}
 
 %start start

--- a/REInteractiveAPI/ReLoad.fsx
+++ b/REInteractiveAPI/ReLoad.fsx
@@ -6,12 +6,15 @@
 #r "nuget:AutomaticGraphLayout.Drawing,1.1.9"
 #r "nuget:SixLabors.ImageSharp,1.0.1"
 #r "nuget:SixLabors.ImageSharp.Drawing,1.0.0-beta0010"
+#r "nuget:XPlot.Plotly,3.0.1"
+#r "nuget:Microsoft.DotNet.Interactive.Formatting, 1.0.0-beta.23606.2"
 
 #r @"bin/Release/netstandard2.0/ReasoningEngine.dll"
 #r @"bin/Release/netstandard2.0/REIN.dll"
 #r @"bin/Release/netstandard2.0/REInteractiveAPI.dll"
 
 open Microsoft.Research.RENotebook
+open Microsoft.DotNet.Interactive.Formatting
 
 type ReilAPI = Microsoft.Research.RENotebook.REIL
 type ReinAPI = Microsoft.Research.RENotebook.REIN
@@ -20,19 +23,23 @@ module Var = Microsoft.Research.ReasoningEngine.Var
 type TrajVis = Microsoft.Research.RENotebook.Lib.TrajectoryVisualization
 printfn "Loading the Reasoning Engine (RE)..."
 
-Formatter.Register<Microsoft.Research.RENotebook.Lib.PlotlyOutput>(
-    mimeType = "text/html",
-    formatter = Func<_,_,_,_>(fun context plotly (writer: TextWriter) ->
-        match plotly with
-        | Microsoft.Research.RENotebook.Lib.PlotlyOutput.Chart plot -> display(plot) |> ignore
-        | Microsoft.Research.RENotebook.Lib.PlotlyOutput.Message stuff -> display(stuff) |> ignore
-        true))
 
-Formatter.Register<Microsoft.Research.RENotebook.Lib.HtmlOutput>(
+Formatter.Register<Lib.PlotlyOutput>(
     mimeType = "text/html",
-    formatter = Func<_,_,_,_>(fun context htmlOutput (writer: TextWriter) ->
-        match htmlOutput with Microsoft.Research.RENotebook.Lib.HtmlOutput html -> display(HTML(html)) |> ignore
-        true))
+    formatter = fun plotly (context: FormatContext) ->
+        match plotly with
+        | Lib.PlotlyOutput.Chart plot -> context.Writer.Write(plot)
+        | Lib.PlotlyOutput.Message stuff -> context.Writer.Write(stuff)
+        true)
+
+
+
+Formatter.Register<Lib.HtmlOutput>(
+    mimeType = "text/html",
+    formatter = fun htmlOutput (context: FormatContext) ->
+        match htmlOutput with Lib.HtmlOutput html -> context.Writer.Write(html)
+        true)
+
 
 // Lists the required and disallowed interactions in a table
 let DrawInteractions required disallowed = 

--- a/RESIN/Parser.fs
+++ b/RESIN/Parser.fs
@@ -10,17 +10,17 @@ open Microsoft.Research.ReasoningEngine.Constraint
 open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
-#indent "off"
+
 
 //arithmetic term
 type Line = 
-	|Assign of string * BExpr
-	|Sync of bool // synchronous update?  
-	|Assert of string * int * BExpr  * string * bool //experiment * step * expression * description * asyncFlag	
-	|Species of string * int list * bool * bool //name * allowed logics * KO? * FE?
-	|Cell of string * (string * string * bool * bool) seq // name * interactions; interactions are source * target * positive? * definite? * id
-	|Switch of string * string * BExpr// cell name 1 * cell name 2 * condition 
-	
+    |Assign of string * BExpr
+    |Sync of bool // synchronous update?  
+    |Assert of string * int * BExpr  * string * bool //experiment * step * expression * description * asyncFlag    
+    |Species of string * int list * bool * bool //name * allowed logics * KO? * FE?
+    |Cell of string * (string * string * bool * bool) seq // name * interactions; interactions are source * target * positive? * definite? * id
+    |Switch of string * string * BExpr// cell name 1 * cell name 2 * condition 
+    
 
 # 25 "Parser.fs"
 // This type is the type of tokens accepted by the parser

--- a/RESIN/Parser.fsy
+++ b/RESIN/Parser.fsy
@@ -4,17 +4,15 @@ open Microsoft.Research.ReasoningEngine.Constraint
 open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
-#indent "off"
-
 //arithmetic term
 type Line = 
-	|Assign of string * BExpr
-	|Sync of bool // synchronous update?  
-	|Assert of string * int * BExpr  * string * bool //experiment * step * expression * description * asyncFlag	
-	|Species of string * int list * bool * bool //name * allowed logics * KO? * FE?
-	|Cell of string * (string * string * bool * bool) seq // name * interactions; interactions are source * target * positive? * definite? * id
-	|Switch of string * string * BExpr// cell name 1 * cell name 2 * condition 
-	
+    |Assign of string * BExpr
+    |Sync of bool // synchronous update?  
+    |Assert of string * int * BExpr  * string * bool //experiment * step * expression * description * asyncFlag    
+    |Species of string * int list * bool * bool //name * allowed logics * KO? * FE?
+    |Cell of string * (string * string * bool * bool) seq // name * interactions; interactions are source * target * positive? * definite? * id
+    |Switch of string * string * BExpr// cell name 1 * cell name 2 * condition 
+    
 %}
 
 %start start

--- a/ReasoningEngine/Parser.fs
+++ b/ReasoningEngine/Parser.fs
@@ -9,15 +9,13 @@ open Var
 open Constraint
 open Dynamics
 
-#indent "off"
-
 type Line = 
-	|VarDecl of VarDef
-	|Assert of BExpr
-	|UpdateDecl of Update
+    |VarDecl of VarDef
+    |Assert of BExpr
+    |UpdateDecl of Update
 
 and Spec =
-	|Spec of Line list
+    |Spec of Line list
 
 # 22 "Parser.fs"
 // This type is the type of tokens accepted by the parser
@@ -894,7 +892,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 131 "Parser.fsy"
-                                                 _2		  
+                                                 _2
                    )
 # 131 "Parser.fsy"
                  : 'NExpr));
@@ -941,7 +939,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 135 "Parser.fsy"
-                                           Neg(_2)	  
+                                           Neg(_2)
                    )
 # 135 "Parser.fsy"
                  : 'NExpr));
@@ -952,7 +950,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 136 "Parser.fsy"
-                                       NTerm(_1)	  
+                                       NTerm(_1)
                    )
 # 136 "Parser.fsy"
                  : 'NExpr));

--- a/ReasoningEngine/Parser.fsy
+++ b/ReasoningEngine/Parser.fsy
@@ -3,12 +3,10 @@ open Var
 open Constraint
 open Dynamics
 
-#indent "off"
-
 type Line = 
-	|VarDecl of VarDef
-	|Assert of BExpr
-	|UpdateDecl of Update
+    |VarDecl of VarDef
+    |Assert of BExpr
+    |UpdateDecl of Update
 
 and Spec =
 	|Spec of Line list
@@ -56,7 +54,7 @@ start: Lines {Spec($1)}
 
 Lines:
 	|Line EOL Lines			{ $1::$3 }
-	|Line EOL				{ [$1]   }	    
+	|Line EOL				{ [$1]   }
 
 Line:	
 	|VarDecl							{VarDecl($1)}
@@ -91,13 +89,13 @@ Scope:
 
 Expr:
 	|NExpr						{NExpr($1)}
-	|BExpr						{BExpr($1)}	
+	|BExpr						{BExpr($1)}
 
 BTerm: 
 	| CExpr						{BTerm(BComp($1))}
     | TRUE						{BTerm(BConst(true))}
 	| FALSE						{BTerm(BConst(false))}
-	| LPAREN BExpr RPAREN		{$2}	
+	| LPAREN BExpr RPAREN		{$2}
 	| Var						{BTerm(BVar($1))}
 
 
@@ -111,29 +109,29 @@ BExpr:
 	| BExpr IMPLIES BExpr		{Imp($1,$3)}
     | BExpr AND BExpr			{And($1,$3)}
     | BExpr OR BExpr			{Or($1,$3)}
-    | NOT BTerm					{Not($2)}	
+    | NOT BTerm					{Not($2)}
 	
 CExpr:	
     |NExpr GT NExpr				{Gt($1,$3)}
-	|NExpr GE NExpr      		{Ge($1,$3)}	
-	|NExpr LT NExpr				{Lt($1,$3)}	
-	|NExpr LE NExpr				{Le($1,$3)}	
-	|NExpr EQ NExpr				{Eq($1,$3)}	
+	|NExpr GE NExpr      		{Ge($1,$3)}
+	|NExpr LT NExpr				{Lt($1,$3)}
+	|NExpr LE NExpr				{Le($1,$3)}
+	|NExpr EQ NExpr				{Eq($1,$3)}
 
 
 NTerm:       
 	| INT32									{NConst($1)}
 	| Var									{NVar($1)}
 	| CARD LPAREN BExprList RPAREN			{Card($3)}
-	| IF BExpr THEN NExpr ELSE NExpr		{Ite($2,$4,$6)}	
+	| IF BExpr THEN NExpr ELSE NExpr		{Ite($2,$4,$6)}
 
 NExpr: 
-	| LPAREN NExpr RPAREN				{ $2		  }		
+	| LPAREN NExpr RPAREN				{ $2		  }
     | NExpr PLUS  NExpr					{ Add($1, $3) }
     | NExpr MINUS NExpr					{ Sub($1, $3) }
     | NExpr MUL NExpr					{ Mul($1, $3) }
 	| MINUS NExpr						{ Neg($2)	  }
-	| NTerm								{ NTerm($1)	  }	
+	| NTerm								{ NTerm($1)	  }
 
 Var:
 	| VAR											{SysVar($1)}
@@ -142,7 +140,7 @@ Var:
 	| PATHNAME LSBRA INT32 RSBRA DOT VAR			{StateVar($1,$3,$6)}
 	| P LSBRA INT32 RSBRA DOT VAR					{AbsPStateVar($3,$6)}
 	| PATHNAME LSBRA K RSBRA DOT VAR				{AbsKStateVar($1,0,$6)}
-	| PATHNAME LSBRA K MINUS INT32 RSBRA DOT VAR	{AbsKStateVar($1,-$5,$8)}		
+	| PATHNAME LSBRA K MINUS INT32 RSBRA DOT VAR	{AbsKStateVar($1,-$5,$8)}
 	| P LSBRA K RSBRA DOT VAR						{AbsStateVar(0,$6)}
 	| P LSBRA K MINUS INT32 RSBRA DOT VAR			{AbsStateVar(-$5,$8)}
 
@@ -152,7 +150,7 @@ Var:
 //*************************************************
 
 Updates:
-	|UpdateR				{ [$1]   }	    
+	|UpdateR				{ [$1]   }
 	|UpdateR COMMA Updates	{ $1::$3 }
 
 
@@ -161,5 +159,5 @@ VarList:
 	| P LSBRA K RSBRA DOT VAR COMMA VarList {$6::$8}
 
 UpdateR:	
-	|P LSBRA K RSBRA DOT VAR ASSIGN Expr	{UpdateRule.Create($6,$8)}	
-	|VarList RELATE BExpr					{UpdateRule.CreateRelation($1,$3)}	
+	|P LSBRA K RSBRA DOT VAR ASSIGN Expr	{UpdateRule.Create($6,$8)}
+	|VarList RELATE BExpr					{UpdateRule.CreateRelation($1,$3)}

--- a/ReinMoCo/Parser.fs
+++ b/ReinMoCo/Parser.fs
@@ -12,23 +12,23 @@ open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
 
-#indent "off"
+
 
 type Line = 
-	| Assign of string * BExpr
-	| Assert of BExpr  * string option	 //boolean expression * description	option
-	| Interaction of string * string * bool * bool //source * target * positive? * definite?
-	| Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
-	| Directive of Directive //possibly, create more structured directives
-	| Motif of string * ((string * string * bool * bool) list)
-	
+    | Assign of string * BExpr
+    | Assert of BExpr  * string option     //boolean expression * description    option
+    | Interaction of string * string * bool * bool //source * target * positive? * definite?
+    | Species of string * int list option * bool * bool * bool //name * allowed logics * KO? * FE? * must be activated
+    | Directive of Directive //possibly, create more structured directives
+    | Motif of string * ((string * string * bool * bool) list)
+    
 and Directive = 
-	|Uniqueness		   of Settings.Uniqueness
+    |Uniqueness           of Settings.Uniqueness
     |Interaction_limit of int option
-    |Regulation		   of Settings.RegulationConditions
-    |Traj_length	   of int
-    |Updates		   of Settings.Updates		
-	|PreventRepeats
+    |Regulation           of Settings.RegulationConditions
+    |Traj_length       of int
+    |Updates           of Settings.Updates        
+    |PreventRepeats
 
 # 33 "Parser.fs"
 // This type is the type of tokens accepted by the parser
@@ -601,7 +601,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 73 "Parser.fsy"
-                                                          Assign(_1,_4)		  
+                                                          Assign(_1,_4)          
                    )
 # 73 "Parser.fsy"
                  : 'Line));
@@ -613,7 +613,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 74 "Parser.fsy"
-                                                               Motif(_1,_4)		  
+                                                               Motif(_1,_4)          
                    )
 # 74 "Parser.fsy"
                  : 'Line));
@@ -667,7 +667,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 81 "Parser.fsy"
-                                           Uniqueness(Settings.Model)		
+                                           Uniqueness(Settings.Model)        
                    )
 # 81 "Parser.fsy"
                  : 'Directive));
@@ -677,7 +677,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 82 "Parser.fsy"
-                                            Uniqueness(Settings.All)			
+                                            Uniqueness(Settings.All)            
                    )
 # 82 "Parser.fsy"
                  : 'Directive));
@@ -689,7 +689,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 83 "Parser.fsy"
-                                                    Uniqueness(Settings.Path(_3,_4))	
+                                                    Uniqueness(Settings.Path(_3,_4))    
                    )
 # 83 "Parser.fsy"
                  : 'Directive));
@@ -699,7 +699,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 84 "Parser.fsy"
-                                              Regulation(Settings.Default)		
+                                              Regulation(Settings.Default)        
                    )
 # 84 "Parser.fsy"
                  : 'Directive));
@@ -709,7 +709,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 85 "Parser.fsy"
-                                                 Regulation(Settings.Cardinality)	
+                                                 Regulation(Settings.Cardinality)    
                    )
 # 85 "Parser.fsy"
                  : 'Directive));
@@ -719,7 +719,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 86 "Parser.fsy"
-                                             Regulation(Settings.Legacy)		
+                                             Regulation(Settings.Legacy)        
                    )
 # 86 "Parser.fsy"
                  : 'Directive));
@@ -729,7 +729,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 87 "Parser.fsy"
-                                                 Regulation(Settings.NoThresholds)	
+                                                 Regulation(Settings.NoThresholds)    
                    )
 # 87 "Parser.fsy"
                  : 'Directive));
@@ -739,7 +739,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 88 "Parser.fsy"
-                                         Updates(Settings.Synchronous)		
+                                         Updates(Settings.Synchronous)        
                    )
 # 88 "Parser.fsy"
                  : 'Directive));
@@ -749,7 +749,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 89 "Parser.fsy"
-                                          Updates(Settings.Asynchronous)	
+                                          Updates(Settings.Asynchronous)    
                    )
 # 89 "Parser.fsy"
                  : 'Directive));
@@ -760,7 +760,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 90 "Parser.fsy"
-                                        Interaction_limit(Some(_2))		
+                                        Interaction_limit(Some(_2))        
                    )
 # 90 "Parser.fsy"
                  : 'Directive));
@@ -771,7 +771,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 91 "Parser.fsy"
-                                         Traj_length(_2)					
+                                         Traj_length(_2)                    
                    )
 # 91 "Parser.fsy"
                  : 'Directive));

--- a/ReinMoCo/Parser.fsy
+++ b/ReinMoCo/Parser.fsy
@@ -6,7 +6,6 @@ open Microsoft.Research.ReasoningEngine.Var
 open System.Collections.Generic
 
 
-#indent "off"
 
 type Line = 
 	| Assign of string * BExpr


### PR DESCRIPTION
It would be good to update to use the project system for https://fsprojects.github.io/FsLexYacc/ that way the parsers and lexers would also be updated at build time. Left as a TODO for someone else.